### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from nginx:alpine
 
-COPY . /usr/share/nginx/html
+COPY index.html /usr/share/nginx/html
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Exited /docker-entrypoint.sh: exec: line 47: c: not found